### PR TITLE
fix 7.2-client connect 7.2-server with obfuscation

### DIFF
--- a/7.2.diff
+++ b/7.2.diff
@@ -1,7 +1,19 @@
 diff -Nurp openssh-7.2p1/kex.c openssh-7.2p1-ob/kex.c
 --- openssh-7.2p1/kex.c	2016-02-26 11:40:04.000000000 +0800
-+++ openssh-7.2p1-ob/kex.c	2016-03-11 17:27:51.318367562 +0800
-@@ -421,6 +421,7 @@ kex_input_newkeys(int type, u_int32_t se
++++ openssh-7.2p1-ob/kex.c	2016-03-12 09:53:42.103587618 +0800
+@@ -359,9 +359,11 @@ kex_send_newkeys(struct ssh *ssh)
+ 	debug("SSH2_MSG_NEWKEYS sent");
+ 	debug("expecting SSH2_MSG_NEWKEYS");
+ 	ssh_dispatch_set(ssh, SSH2_MSG_NEWKEYS, &kex_input_newkeys);
++	sshpkt_disable_obfuscation();
+ 	if (ssh->kex->ext_info_c)
+ 		if ((r = kex_send_ext_info(ssh)) != 0)
+ 			return r;
++	sshpkt_enable_obfuscation();
+ 	return 0;
+ }
+ 
+@@ -421,6 +423,7 @@ kex_input_newkeys(int type, u_int32_t se
  	kex->flags &= ~KEX_INIT_SENT;
  	free(kex->name);
  	kex->name = NULL;

--- a/7.2.diff
+++ b/7.2.diff
@@ -1,19 +1,21 @@
 diff -Nurp openssh-7.2p1/kex.c openssh-7.2p1-ob/kex.c
 --- openssh-7.2p1/kex.c	2016-02-26 11:40:04.000000000 +0800
-+++ openssh-7.2p1-ob/kex.c	2016-03-12 09:53:42.103587618 +0800
-@@ -359,9 +359,11 @@ kex_send_newkeys(struct ssh *ssh)
++++ openssh-7.2p1-ob/kex.c	2016-03-12 10:44:35.680336240 +0800
+@@ -359,9 +359,12 @@ kex_send_newkeys(struct ssh *ssh)
  	debug("SSH2_MSG_NEWKEYS sent");
  	debug("expecting SSH2_MSG_NEWKEYS");
  	ssh_dispatch_set(ssh, SSH2_MSG_NEWKEYS, &kex_input_newkeys);
-+	sshpkt_disable_obfuscation();
- 	if (ssh->kex->ext_info_c)
+-	if (ssh->kex->ext_info_c)
++	if (ssh->kex->ext_info_c) {
++		sshpkt_disable_obfuscation();
  		if ((r = kex_send_ext_info(ssh)) != 0)
  			return r;
-+	sshpkt_enable_obfuscation();
++		sshpkt_enable_obfuscation();
++	}
  	return 0;
  }
  
-@@ -421,6 +423,7 @@ kex_input_newkeys(int type, u_int32_t se
+@@ -421,6 +424,7 @@ kex_input_newkeys(int type, u_int32_t se
  	kex->flags &= ~KEX_INIT_SENT;
  	free(kex->name);
  	kex->name = NULL;


### PR DESCRIPTION
Previous patch has a bug that 7.2-server will send a obfuscated MSG_EXT_INFO to MSG_NEWKEYS-received 7.2-client

now 7.2-Server send MSG_EXT_INFO without obfuscation, then enable obfuscation to decode received MSG_NEWKEYS
